### PR TITLE
feat(versioning): Add versioned sync commands for game save management

### DIFF
--- a/tauri-ui/src/main.rs
+++ b/tauri-ui/src/main.rs
@@ -77,6 +77,12 @@ async fn main() {
             commands::get_steam_save_suggestions,
             commands::add_steam_game_to_config,
             commands::test_steam_detection,
+            // Versioned sync commands
+            commands::sync_game_with_versioning,
+            commands::get_version_history,
+            commands::restore_version,
+            commands::pin_version,
+            commands::cleanup_old_versions,
         ])
         .setup(|app| {
             // Setup tray icon


### PR DESCRIPTION
Introducing a new feature for versioned game save synchronization, adding significant functionality for managing game save versions, including syncing, version history, restoration, and cleanup. The changes span across the core logic, API commands, and application setup.

### Core functionality for versioned game save synchronization:
* Added `VersionedGameSaveSync` struct to handle versioned synchronization, including methods for syncing game saves, managing version history, restoring specific versions, pinning versions, and cleaning up old versions. (`core/src/lib.rs`)
* Exposed key versioning-related types and structs (`VersionManager`, `FileVersion`, etc.) for broader use. (`core/src/lib.rs`)

### API commands for versioned synchronization:
* Introduced Tauri commands for versioned sync operations, including `sync_game_with_versioning`, `get_version_history`, `restore_version`, `pin_version`, and `cleanup_old_versions`. These commands enable interaction with the versioned sync functionality from the frontend. (`tauri-ui/src/commands.rs`)

### Application setup:
* Registered new versioned sync commands in the Tauri application initialization. (`tauri-ui/src/main.rs`)